### PR TITLE
Revert "manage broker ids"

### DIFF
--- a/kafka/files/server.properties
+++ b/kafka/files/server.properties
@@ -19,7 +19,7 @@
 ############################# Server Basics #############################
 
 # The id of the broker. This must be set to a unique integer for each broker.
-broker.id={{ kafka.broker_id }}
+broker.id=0
 
 ############################# Socket Server Settings #############################
 

--- a/kafka/settings.sls
+++ b/kafka/settings.sls
@@ -8,17 +8,6 @@
 
 {%- set chroot_path = gc.get('chroot_path', pc.get('chroot_path', 'kafka')) %}
 
-{%- set targeting_method  = g.get('targeting_method', p.get('targeting_method', 'grain')) %}
-{%- set hosts_target      = g.get('hosts_target', p.get('hosts_target', 'roles:kafka')) %}
-
-{%- set broker_hosts = salt.mine.get(hosts_target, 'network.get_hostname', targeting_method).values() | sort () %}
-
-{%- set brokers_with_ids = {} %}
-{%- for i in range(broker_hosts | length()) %}
-  {%- do brokers_with_ids.update({ broker_hosts[i] : i }) %}
-{%- endfor %}
-
-{%- set broker_id = brokers_with_ids.get(salt.network.get_hostname(), '') %}
 
 {%- set config_properties = gc.get('properties', pc.get('properties', {})) %}
 
@@ -27,6 +16,5 @@
   'heap_initial_size' : heap_initial_size,
   'heap_max_size'     : heap_max_size,
   'chroot_path'       : chroot_path,
-  'broker_id'         : broker_id,
   'config_properties' : config_properties,
 }) %}


### PR DESCRIPTION
Reverts saltstack-formulas/kafka-formula#4

Kafka does broker id generation starting around 0.9.x.x. This change no longer seems useful.