### PR TITLE
unset default broker id

### DIFF
--- a/kafka/files/server.properties
+++ b/kafka/files/server.properties
@@ -19,7 +19,7 @@
 ############################# Server Basics #############################
 
 # The id of the broker. This must be set to a unique integer for each broker.
-broker.id=0
+# broker.id=0
 
 ############################# Socket Server Settings #############################
 


### PR DESCRIPTION
Users can still manage the broker ID themselves via `config_properties`.