### PR TITLE
Kafka Schema Registry states

### DIFF
--- a/kafka/files/schema-registry.properties
+++ b/kafka/files/schema-registry.properties
@@ -1,0 +1,25 @@
+{%- from 'kafka/settings.sls' import kafka with context %}
+# Copyright 2014 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+listeners=http://0.0.0.0:8081
+
+{%- if kafka.chroot_path %}
+kafkastore.connection.url={{ zookeepers }}/{{ kafka.chroot_path }}
+{%- else %}
+kafkastore.connection.url={{ zookeepers }}
+{%- endif %}
+
+kafkastore.topic=_schemas
+debug=false

--- a/kafka/files/schema-registry.service
+++ b/kafka/files/schema-registry.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Kafka Schema Registry
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/schema-registry-start /etc/schema-registry/schema-registry.peroperties
+
+[Install]
+WantedBy=multi-user.target

--- a/kafka/files/schema-registry.service
+++ b/kafka/files/schema-registry.service
@@ -3,7 +3,7 @@ Description=Kafka Schema Registry
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/schema-registry-start /etc/schema-registry/schema-registry.peroperties
+ExecStart=/usr/bin/schema-registry-start /etc/schema-registry/schema-registry.properties
 
 [Install]
 WantedBy=multi-user.target

--- a/kafka/schema-registry.sls
+++ b/kafka/schema-registry.sls
@@ -11,3 +11,13 @@ configure Schema Registry:
     - template: jinja
     - context:
       zookeepers: {{ zk.connection_string }}
+
+systemd unit file for Schema Registry:
+  file.managed:
+    - name: /lib/systemd/system/schema-registry.service
+    - source: salt://kafka/files/schema-registry.service
+
+start Schema Registry service:
+  service.running:
+    - name: schema-registry
+    - enable: True

--- a/kafka/schema-registry.sls
+++ b/kafka/schema-registry.sls
@@ -1,0 +1,13 @@
+{%- from 'zookeeper/settings.sls' import zk with context %}
+
+install Kafka Schema Registry:
+  pkg.installed:
+    - name: confluent-schema-registry
+
+configure Schema Registry:
+  file.managed:
+    - name: /etc/schema-registry/schema-registry.properties
+    - source: salt://kafka/files/schema-registry.properties
+    - template: jinja
+    - context:
+      zookeepers: {{ zk.connection_string }}


### PR DESCRIPTION
* Confluent packaging does not include an init script of any kind.
* `host.name` property is required for clustered setup.