### PR TITLE
disable Confluent support metrics

### DIFF
--- a/kafka/files/server.properties
+++ b/kafka/files/server.properties
@@ -125,7 +125,7 @@ zookeeper.connection.timeout.ms=6000
 # then the feature to collect and report support metrics
 # ("Metrics") is enabled.  If set to false, the feature is disabled.
 #
-confluent.support.metrics.enable=true
+confluent.support.metrics.enable=false
 
 # The customer ID under which support metrics will be collected and
 # reported.


### PR DESCRIPTION
Users can submit PR if they need it enabled.