### PR TITLE
Fixed Template to use JAVA_HOME

### DIFF
--- a/kafka/files/kafka.default
+++ b/kafka/files/kafka.default
@@ -1,6 +1,6 @@
 {%- from 'kafka/settings.sls' import kafka with context %}
 
-JAVA_HOME={{ java_home }}
+JAVA_HOME={{ kafka.java_home }}
 
 # whether to allow init.d script to start a kafka broker ("yes", "no")
 KAFKA_START=no


### PR DESCRIPTION
Now kafka.default is able to use the variable "java_home"